### PR TITLE
fixing go back button on new tabs

### DIFF
--- a/src/templates/Post.vue
+++ b/src/templates/Post.vue
@@ -9,7 +9,7 @@
       </p>
     </div>
     <div class="post-content">
-      <p v-html="$page.post.content" />
+      <div v-html="$page.post.content" />
     </div>
   </Layout>
 </template>


### PR DESCRIPTION
Fixing the problem: when the direct url of a post is opened go back button does not work